### PR TITLE
Support `mini_portile ~> 2`

### DIFF
--- a/image_compressor_pack.gemspec
+++ b/image_compressor_pack.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.extensions    = ["ext/image_compressor_pack/extconf.rb"]
 
-  spec.add_runtime_dependency "mini_portile2", "> 2.2.0rc"
+  spec.add_runtime_dependency "mini_portile2", "~> 2"
 
   spec.add_development_dependency "bundler", "~> 1"
   spec.add_development_dependency "rake", "~> 11"

--- a/lib/image_compressor_pack/recipes.rb
+++ b/lib/image_compressor_pack/recipes.rb
@@ -1,6 +1,7 @@
 require 'mini_portile2'
 require 'yaml'
 require 'rbconfig'
+require_relative '../mini_portile2/mini_portile_cmake'
 
 module ImageCompressorPack
   def self.recipes

--- a/lib/mini_portile2/mini_portile_cmake.rb
+++ b/lib/mini_portile2/mini_portile_cmake.rb
@@ -1,4 +1,9 @@
 require 'mini_portile2/mini_portile'
+class MiniPortile
+  def self.windows?
+    RbConfig::CONFIG['target_os'] =~ /mswin|mingw32/
+  end
+end
 
 class MiniPortileCMake < MiniPortile
   def configure_prefix

--- a/lib/mini_portile2/mini_portile_cmake.rb
+++ b/lib/mini_portile2/mini_portile_cmake.rb
@@ -1,0 +1,41 @@
+require 'mini_portile2/mini_portile'
+
+class MiniPortileCMake < MiniPortile
+  def configure_prefix
+    "-DCMAKE_INSTALL_PREFIX=#{File.expand_path(port_path)}"
+  end
+
+  def configure_defaults
+    if MiniPortile.windows?
+      ['-G "NMake Makefiles"']
+    else
+      []
+    end
+  end
+
+  def configure
+    return if configured?
+
+    md5_file = File.join(tmp_path, 'configure.md5')
+    digest   = Digest::MD5.hexdigest(computed_options.to_s)
+    File.open(md5_file, "w") { |f| f.write digest }
+
+    execute('configure', %w(cmake) + computed_options + ["."])
+  end
+
+  def configured?
+    configure = File.join(work_path, 'configure')
+    makefile  = File.join(work_path, 'CMakefile')
+    md5_file  = File.join(tmp_path, 'configure.md5')
+
+    stored_md5  = File.exist?(md5_file) ? File.read(md5_file) : ""
+    current_md5 = Digest::MD5.hexdigest(computed_options.to_s)
+
+    (current_md5 == stored_md5) && newer?(makefile, configure)
+  end
+
+  def make_cmd
+    return "nmake" if MiniPortile.windows?
+    super
+  end
+end


### PR DESCRIPTION
This PR inlines the cmake support from `mini_portile2 2.2.0rc` so that this gem will be compatible with the latest release version of `mini_portile`.

My use-case is using  `image_compressor_pack` in a Rails project alongside `nokogiri`, which has a dependency conflict with the `2.2.0rc` version of `mini_portile`.

It's a bit of a hack so feel free to close, just thought I'd share what worked for me.

Thanks for the gem!